### PR TITLE
Typo in command options

### DIFF
--- a/cmds/back.js
+++ b/cmds/back.js
@@ -4,7 +4,7 @@ const { MessageEmbed } = require("discord.js");
 module.exports = {
     name: "back",
     description: "Skips the current song",
-    alises: ["bk","previous","prev","pr"],
+    aliases: ["bk","previous","prev","pr"],
     clientRequiredPermissions: ["SEND_MESSAGES"],
     run: async({client, interaction, respond, guild, edit, member}, args) => {
       let error = (c) => respond({ content: `:x: *${c}*`, ephemeral: true });

--- a/cmds/clearqueue.js
+++ b/cmds/clearqueue.js
@@ -4,7 +4,7 @@ const { MessageEmbed } = require("discord.js");
 module.exports = {
     name: "clearqueue",
     description: "Clears the queue",
-    alises: ["clr","clear","clearq","clrqueue","deletequeue","delqueue","clearq","deleteq"],
+    aliases: ["clr","clear","clearq","clrqueue","deletequeue","delqueue","clearq","deleteq"],
     clientRequiredPermissions: ["SEND_MESSAGES"],
     run: async({client, interaction, respond, guild, edit, member}, args) => {
       let error = (c) => respond({ content: `:x: *${c}*`, ephemeral: true });

--- a/cmds/jump.js
+++ b/cmds/jump.js
@@ -12,7 +12,7 @@ module.exports = {
         required: true
       }
     ],
-    alises: ["j"],
+    aliases: ["j"],
     clientRequiredPermissions: ["SEND_MESSAGES","CONNECT","SPEAK"],
     run: async({client, interaction, respond, guild, edit, member}, args) => {
       let error = (c) => respond({ content: `:x: *${c}*`, ephemeral: true });

--- a/cmds/remove.js
+++ b/cmds/remove.js
@@ -12,7 +12,7 @@ module.exports = {
         required: true
       }
     ],
-    alises: ["rem","re"],
+    aliases: ["rem","re"],
     clientRequiredPermissions: ["SEND_MESSAGES","EMBED_LINKS"],
     run: async({client, interaction, respond, guild, edit, member}, args) => {
       let error = (c) => respond({ content: `:x: *${c}*`, ephemeral: true });

--- a/cmds/skip.js
+++ b/cmds/skip.js
@@ -4,7 +4,7 @@ const { MessageEmbed } = require("discord.js");
 module.exports = {
     name: "skip",
     description: "Skips the current song",
-    alises: ["sk","n"],
+    aliases: ["sk","n"],
     clientRequiredPermissions: ["SEND_MESSAGES"],
     run: async({client, interaction, respond, guild, edit, member}, args) => {
       let error = (c) => respond({ content: `:x: *${c}*`, ephemeral: true });


### PR DESCRIPTION
Some typos in the options of some commands where there is `alises` instead of `aliases`